### PR TITLE
Automatically get a set object with at least 1 child

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # ensemble-rewrite-test
-Tests the rewrite methods of MH
+
+Tests the rewrite methods of MH.
 
 ## Goal
+
 This code tests the MH API to:
 - List children within an ensemble
 - Delete a child from an ensemble
@@ -9,14 +11,17 @@ This code tests the MH API to:
 - Rewrite the whole ensemble
 
 ## Usage
+
 Run the code using python3 in the following manner:
-`python3 test_complex_objects.py --fragment_id 3274e0c3b03743dda7f96ec0b28d904f9bdcc87f625645a69dde31ccaea0b3e907198c9d6b0d480a9f6af70862663c6e --username myusername --password mypwd`
+
+```$ python3 test_complex_objects.py --fragment_id 3274e0c3b03743dda7f96ec0b28d904f9bdcc87f625645a69dde31ccaea0b3e907198c9d6b0d480a9f6af70862663c6e --username myusername --password mypwd```
 
 Optionally, an environment (`--environment QAS` or `--environment PRD`) can be used to perform the tests on either of those environments (run in PRD at your own risk!).
 
-The `fragment_id` parameter must be a `fragment_id` from an ensemble. The code will list how many (and which) children the object has, delete one, re-add it, and completely re-write the ensemble.
+The code will list how many (and which) children the object has, delete one, re-add it, and completely re-write the ensemble.
 
 ### Example output:
+
 ```
 2018-02-08 09:30:12,514   INFO    : Running in environment: QAS
 2018-02-08 09:30:14,017   INFO    : Fragment has 25 children:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This code tests the MH API to:
 
 Run the code using python3 in the following manner:
 
-```$ python3 test_complex_objects.py --fragment_id 3274e0c3b03743dda7f96ec0b28d904f9bdcc87f625645a69dde31ccaea0b3e907198c9d6b0d480a9f6af70862663c6e --username myusername --password mypwd```
+```$ python3 test_complex_objects.py --username myusername --password mypwd```
 
 Optionally, an environment (`--environment QAS` or `--environment PRD`) can be used to perform the tests on either of those environments (run in PRD at your own risk!).
 

--- a/src/test_complex_objects.py
+++ b/src/test_complex_objects.py
@@ -38,15 +38,17 @@ def main():
     getsetrequest = requests.get(getseturl + '?q=%2B(MediaObjectType:Set)',
                                  auth=HTTPBasicAuth(arguments.username, arguments.password))
     getsetresponse = getsetrequest.json();
-    getsetrequestnrofresults = getsetresponse['totalNrOfResults']
-    if getsetrequestnrofresults > 0:
-        setresults = getsetresponse['mediaDataList']
+    nr_of_results = getsetresponse['totalNrOfResults']
+    logging.info('totalNrOfResults is: %s' % nr_of_results)
+    setresults = getsetresponse['mediaDataList']
+    if setresults:
         for complex in setresults:
             fragmentid = complex['fragmentId']
+            logging.debug('Checking fragmentId "%s" for children...' % fragmentid)
             nrofchildren = checknumberofchildren(arguments, fragmentid)
             if nrofchildren > 0:
-                logging.info('Found a set (' + fragmentid + ') with ' + str(nrofchildren) + ' children.')
-                #~ performoperations(arguments, fragmentid)
+                logging.info('Found a set (%s) with %s children.' % (fragmentid, nrofchildren))
+                performoperations(arguments, fragmentid)
                 break
 
 def checknumberofchildren(arguments, fragmentid):

--- a/src/test_complex_objects.py
+++ b/src/test_complex_objects.py
@@ -17,9 +17,14 @@ def main():
     arguments = Arguments()
     init_logger()
     parser = argparse.ArgumentParser()
-    parser.add_argument('--username', help='the username to use when connecting to mediahaven', type=str)
-    parser.add_argument('--password', help='the password to use when connecting to mediahaven', type=str)
-    parser.add_argument('--environment', help='the environment to test. QAS or PRD', type=str)
+    parser.add_argument('-u', '--username', type=str, dest='username',
+            required=True,
+            help='Username to use when connecting to mediahaven.')
+    parser.add_argument('-p', '--password', type=str, dest='password',
+            required=True,
+            help='Password to use when connecting to mediahaven.')
+    parser.add_argument('-e', '--environment', type=str, choices=['QAS', 'PRD'],
+            help='The environment to test. QAS or PRD.')
     parser.parse_args(namespace=arguments)
 
     check_arguments(arguments)
@@ -41,7 +46,7 @@ def main():
             nrofchildren = checknumberofchildren(arguments, fragmentid)
             if nrofchildren > 0:
                 logging.info('Found a set (' + fragmentid + ') with ' + str(nrofchildren) + ' children.')
-                performoperations(arguments, fragmentid)
+                #~ performoperations(arguments, fragmentid)
                 break
 
 def checknumberofchildren(arguments, fragmentid):

--- a/src/test_complex_objects.py
+++ b/src/test_complex_objects.py
@@ -17,7 +17,6 @@ def main():
     arguments = Arguments()
     init_logger()
     parser = argparse.ArgumentParser()
-    #    parser.add_argument('--fragmentid', help='the fragment id of the complex object', type=str)
     parser.add_argument('--username', help='the username to use when connecting to mediahaven', type=str)
     parser.add_argument('--password', help='the password to use when connecting to mediahaven', type=str)
     parser.add_argument('--environment', help='the environment to test. QAS or PRD', type=str)
@@ -126,9 +125,6 @@ def init_logger():
 
 
 def check_arguments(arguments):
-    # if fragmentid is None:
-    #     close("No fragment id specified")
-
     if arguments.username is None:
         close("No username specified")
 

--- a/src/test_complex_objects.py
+++ b/src/test_complex_objects.py
@@ -4,7 +4,6 @@ import random
 import requests
 import time
 from requests.auth import HTTPBasicAuth
-
 from arguments import Arguments
 
 __author__ = 'viaa'
@@ -18,7 +17,7 @@ def main():
     arguments = Arguments()
     init_logger()
     parser = argparse.ArgumentParser()
-    parser.add_argument('--fragment_id', help='the fragment id of the complex object', type=str)
+    #    parser.add_argument('--fragmentid', help='the fragment id of the complex object', type=str)
     parser.add_argument('--username', help='the username to use when connecting to mediahaven', type=str)
     parser.add_argument('--password', help='the password to use when connecting to mediahaven', type=str)
     parser.add_argument('--environment', help='the environment to test. QAS or PRD', type=str)
@@ -28,12 +27,37 @@ def main():
 
     logging.info('Running in environment: ' + arguments.environment)
 
-    url = arguments.baseurl + PATH + arguments.fragment_id + '/children'
+    getseturl = arguments.baseurl + PATH
+    # We need to construct the query ourselves (see https://github.com/requests/requests/issues/1454).
+    # If we don't, the URL will be: '/mediahaven-rest-api/resources/media/?q=%2B%28MediaObjectType%3ASet%29&nrOfResults=1'
+    # Request multiple sets since not all will have children
+    getsetrequest = requests.get(getseturl + '?q=%2B(MediaObjectType:Set)',
+                                 auth=HTTPBasicAuth(arguments.username, arguments.password))
+    getsetresponse = getsetrequest.json();
+    getsetrequestnrofresults = getsetresponse['totalNrOfResults']
+    if getsetrequestnrofresults > 0:
+        setresults = getsetresponse['mediaDataList']
+        for complex in setresults:
+            fragmentid = complex['fragmentId']
+            nrofchildren = checknumberofchildren(arguments, fragmentid)
+            if nrofchildren > 0:
+                logging.info('Found a set (' + fragmentid + ') with ' + str(nrofchildren) + ' children.')
+                performoperations(arguments, fragmentid)
+                break
+
+def checknumberofchildren(arguments, fragmentid):
+    url = arguments.baseurl + PATH + fragmentid + '/children'
     getchildrenrequest = requests.get(url, auth=HTTPBasicAuth(arguments.username, arguments.password))
     jsonresult = getchildrenrequest.json()
     totalnrofresults = jsonresult['totalNrOfResults']
+    return totalnrofresults
+
+
+def performoperations(arguments, fragmentid):
+    url = arguments.baseurl + PATH + fragmentid + '/children'
+    getchildrenrequest = requests.get(url, auth=HTTPBasicAuth(arguments.username, arguments.password))
+    jsonresult = getchildrenrequest.json()
     children = jsonresult['mediaDataList']
-    logging.info('Fragment has ' + str(totalnrofresults) + ' children: ')
 
     rewritedata = []
     counter = 1
@@ -50,25 +74,27 @@ def main():
     deletedchild = children[randomindex]['fragmentId']
 
     # Remove the object from the ensemble
-    url = arguments.baseurl + PATH + arguments.fragment_id + '/children/' + deletedchild
+    url = arguments.baseurl + PATH + fragmentid + '/children/' + deletedchild
     deletefromensemblerequest = requests.delete(url, auth=HTTPBasicAuth(arguments.username, arguments.password))
 
     # Add object back to ensemble
-    url = arguments.baseurl + PATH + arguments.fragment_id + '/children'
+    url = arguments.baseurl + PATH + fragmentid + '/children'
     deletedata = {'id': (None, deletedchild)}
     logging.info('Re-adding the previously deleted object')
-    addensemblerequest = requests.post(url, files=deletedata, auth=HTTPBasicAuth(arguments.username, arguments.password))
+    addensemblerequest = requests.post(url, files=deletedata,
+                                       auth=HTTPBasicAuth(arguments.username, arguments.password))
 
     # Rewrite ensemble
-    url = arguments.baseurl + PATH + arguments.fragment_id + '/children'
+    url = arguments.baseurl + PATH + fragmentid + '/children'
     logging.info('Rewriting the object')
-    rewriteensemblerequest = requests.put(url, files=rewritedata, auth=HTTPBasicAuth(arguments.username, arguments.password))
+    rewriteensemblerequest = requests.put(url, files=rewritedata,
+                                          auth=HTTPBasicAuth(arguments.username, arguments.password))
 
     # Sleep
     logging.info('Sleeping to make sure the update persisted')
     time.sleep(5)
 
-    url = arguments.baseurl + PATH + arguments.fragment_id + '/children'
+    url = arguments.baseurl + PATH + fragmentid + '/children'
     getchildrenrequest = requests.get(url, auth=HTTPBasicAuth(arguments.username, arguments.password))
     jsonresult = getchildrenrequest.json()
     totalnrofresults = jsonresult['totalNrOfResults']
@@ -100,8 +126,8 @@ def init_logger():
 
 
 def check_arguments(arguments):
-    if arguments.fragment_id is None:
-        close("No fragment id specified")
+    # if fragmentid is None:
+    #     close("No fragment id specified")
 
     if arguments.username is None:
         close("No username specified")


### PR DESCRIPTION
Fixes #1 
Note: If there are no set objects within the first 25 items requested from the API with at least one child, it will not work.